### PR TITLE
🎉 Release 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@dependabot[bot]
+@psych0d0g, @dependabot[bot]
 
 ### Misc
 
+- 🎉 Release 0.0.5 [[#6](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/6)]
 - Bump golang.org/x/crypto from 0.16.0 to 0.17.0 [[#5](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/5)]
 - Bump golang.org/x/crypto from 0.16.0 to 0.17.0 [[#5](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/5)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.0.5` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.0.5](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/releases/tag/0.0.5) - 2023-12-19

### Misc

- 🎉 Release 0.0.5 [[#6](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/6)]
- Bump golang.org/x/crypto from 0.16.0 to 0.17.0 [[#5](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/5)]
- Bump golang.org/x/crypto from 0.16.0 to 0.17.0 [[#5](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/5)]